### PR TITLE
Native nixpkgs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "nixpkgs"]
 	path = nixpkgs
-	url = git@github.com:WebGHC/nixpkgs
+	url = https://github.com/WebGHC/nixpkgs
 	branch = wasm-cross

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "nixpkgs"]
+	path = nixpkgs
+	url = git@github.com:WebGHC/nixpkgs
+	branch = wasm-cross

--- a/ci.nix
+++ b/ci.nix
@@ -5,6 +5,8 @@ with import ./.;
   nixpkgs.llvmPackages_HEAD
   nixpkgs.binaryen
   nixpkgs.haskell.compiler.ghcHEAD
+
+  nixpkgsArm.haskellPackages.hello
 ] ++ builtins.concatLists (builtins.map (pkgs: [
   pkgs.stdenv.cc
   pkgs.fib-example

--- a/ci.nix
+++ b/ci.nix
@@ -5,10 +5,7 @@ with import ./.;
   nixpkgs.llvmPackages_HEAD
   nixpkgs.binaryen
   nixpkgs.haskell.compiler.ghcHEAD
-
-  nixpkgsArm.stdenv.cc
-  nixpkgsWasm.stdenv.cc
-
-  nixpkgsArm.fib-example
-  nixpkgsWasm.fib-example
-]
+] ++ builtins.concatLists (builtins.map (pkgs: [
+  pkgs.stdenv.cc
+  pkgs.fib-example
+]) [nixpkgsWasm nixpkgsArm nixpkgsNative])

--- a/cross.nix
+++ b/cross.nix
@@ -89,6 +89,14 @@ in bootStages ++ [
                       enableIntegerSimple = true;
                       # quick-cross = true; # Just for dev
                     };
+                    overrides = self.lib.composeExtensions (drv.overrides or (_:_:{})) (self: super: {
+                      mkDerivation = args: super.mkDerivation (args // {
+                        enableExecutableStripping = false;
+                        enableLibraryStripping = false;
+                        enableSharedExecutables = false;
+                        enableSharedLibraries = false;
+                      });
+                    });
                   });
                 };
               };

--- a/cross.nix
+++ b/cross.nix
@@ -79,6 +79,18 @@ in bootStages ++ [
                 configureFlags = drv.configureFlags or []
                   ++ self.lib.optionals (targetSystem.arch or null == "wasm32") ["--without-progs" "--without-tests"];
               });
+              haskell = let inherit (super) haskell; in haskell // {
+                packages = haskell.packages // {
+                  ghcHEAD = haskell.packages.ghcHEAD.override (drv: {
+                    ghc = drv.ghc.override {
+                      dynamic = false;
+                      enableRelocatedStaticLibs = false;
+                      enableIntegerSimple = true;
+                      quick-cross = true;
+                    };
+                  });
+                };
+              };
             };
             x =
               if localSystem != targetSystem

--- a/cross.nix
+++ b/cross.nix
@@ -123,7 +123,7 @@ in bootStages ++ [
               configureFlags = let
                 flags = args.configureFlags or [];
               in
-                (if builtins.isString flags then [flags] else flags) ++ ["--enable-static" "--disable-shared"];
+                (if builtins.isString flags then [flags] else flags) ++ self.lib.optionals (!(args.dontConfigureStatic or false)) ["--enable-static" "--disable-shared"];
             });
             isStatic = true;
           };

--- a/cross.nix
+++ b/cross.nix
@@ -86,7 +86,7 @@ in bootStages ++ [
                       dynamic = false;
                       enableRelocatedStaticLibs = false;
                       enableIntegerSimple = true;
-                      quick-cross = true;
+                      # quick-cross = true; # Just for dev
                     };
                   });
                 };

--- a/cross.nix
+++ b/cross.nix
@@ -79,6 +79,7 @@ in bootStages ++ [
                 configureFlags = drv.configureFlags or []
                   ++ self.lib.optionals (targetSystem.arch or null == "wasm32") ["--without-progs" "--without-tests"];
               });
+              haskellPackages = self.haskell.packages.ghcHEAD;
               haskell = let inherit (super) haskell; in haskell // {
                 packages = haskell.packages // {
                   ghcHEAD = haskell.packages.ghcHEAD.override (drv: {

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,9 @@
       });
     })];
   };
-  nixpkgsCrossArgs = project.nixpkgsArgs // {};
+  nixpkgsCrossArgs = project.nixpkgsArgs // {
+    stdenvStages = import ./cross.nix;
+  };
 
   nixpkgs = import ./nixpkgs project.nixpkgsArgs;
   nixpkgsWasm = import ./nixpkgs (project.nixpkgsCrossArgs // {
@@ -32,10 +34,11 @@
       arch = "wasm32";
       libc = null;
     };
-    stdenvStages = import ./cross.nix;
   });
   nixpkgsArm = import ./nixpkgs (project.nixpkgsCrossArgs // {
     crossSystem = (import "${(import ./nixpkgs {}).path}/lib/systems/examples.nix").aarch64-multiplatform;
-    stdenvStages = import ./cross.nix;
+  });
+  nixpkgsNative = import ./nixpkgs (project.nixpkgsCrossArgs // {
+    # crossSystem = project.nixpkgs.hostPlatform;
   });
 })

--- a/fib-example/fib.c
+++ b/fib-example/fib.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int fib(int n) {
   if (n == 0 || n == 1) {
     return n;
@@ -7,5 +9,6 @@ int fib(int n) {
 }
 
 int main() {
-  return fib(10);
+  printf("Hello, World!\nfib(10) = %d\n", fib(10));
+  return 0;
 }

--- a/llvm-head/clang/default.nix
+++ b/llvm-head/clang/default.nix
@@ -13,7 +13,7 @@ let
       "-DCMAKE_CXX_FLAGS=-std=c++11"
     ] ++
     # Maybe with compiler-rt this won't be needed?
-    (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
+    # (stdenv.lib.optional stdenv.isLinux "-DGCC_INSTALL_PREFIX=${gcc}") ++
     (stdenv.lib.optional (stdenv.cc.libc != null) "-DC_INCLUDE_DIRS=${stdenv.cc.libc}/include");
 
     patches = [ ./purity.patch ./wasm-lld.patch ];

--- a/llvm-head/compiler-rt.nix
+++ b/llvm-head/compiler-rt.nix
@@ -18,8 +18,11 @@ stdenv.mkDerivation {
     "-DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=${hostPlatform.config}"
   ]
   # TODO: Figure out how to build sanitizers, etc. when cross compiling
-  ++ lib.optionals (hostPlatform != buildPlatform) [ "--target" "../lib/builtins" ]
-  ++ lib.optionals baremetal ["-DCOMPILER_RT_BAREMETAL_BUILD=TRUE" "-DCOMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=TRUE" "-DCMAKE_C_COMPILER_WORKS=1"];
+  ++ lib.optionals baremetal [
+    "--target" "../lib/builtins"
+    "-DCOMPILER_RT_BAREMETAL_BUILD=TRUE"
+    "-DCOMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=TRUE"
+  ];
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra

--- a/llvm-head/default.nix
+++ b/llvm-head/default.nix
@@ -58,7 +58,7 @@ let
         if hostPlatform != targetPlatform
         then "${targetPlatform.config}-"
         else "";
-    in with tools; runCommand "binutils" {} ''
+    in with tools; runCommand "llvm-binutils-${release_version}" {} ''
       mkdir -p $out/bin
       # for prog in ${lld}/bin/*; do
       #   ln -s $prog $out/bin/${prefix}$(basename $prog)
@@ -70,8 +70,8 @@ let
       rm $out/bin/${prefix}cat
 
       ln -s ${lld}/bin/lld $out/bin/${prefix}ld
-      ln -s ${lld}/bin/lld $out/bin/${prefix}ld.lld
-      ln -s ${lld}/bin/lld $out/bin/${prefix}lld
+      # ln -s ${lld}/bin/lld $out/bin/${prefix}ld.lld
+      # ln -s ${lld}/bin/lld $out/bin/${prefix}lld
     '';
   };
 

--- a/llvm-head/default.nix
+++ b/llvm-head/default.nix
@@ -58,17 +58,20 @@ let
         if hostPlatform != targetPlatform
         then "${targetPlatform.config}-"
         else "";
-    in with tools; runCommand "binutils" { propogatedNativeBuildInputs = [ llvm lld ]; } ''
+    in with tools; runCommand "binutils" {} ''
       mkdir -p $out/bin
-      for prog in ${lld}/bin/*; do
-        ln -s $prog $out/bin/${prefix}$(basename $prog)
-      done
+      # for prog in ${lld}/bin/*; do
+      #   ln -s $prog $out/bin/${prefix}$(basename $prog)
+      # done
       for prog in ${llvm}/bin/*; do
         ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
       done
 
+      rm $out/bin/${prefix}cat
+
       ln -s ${lld}/bin/lld $out/bin/${prefix}ld
-      ln -s ${lld}/bin/lld $out/bin/${prefix}ld.gold # TODO: Figure out the ld.gold thing for GHC
+      ln -s ${lld}/bin/lld $out/bin/${prefix}ld.lld
+      ln -s ${lld}/bin/lld $out/bin/${prefix}lld
     '';
   };
 

--- a/llvm-head/llvm-ar.patch
+++ b/llvm-head/llvm-ar.patch
@@ -1,0 +1,24 @@
+diff --git a/tools/llvm-ar/llvm-ar.cpp b/tools/llvm-ar/llvm-ar.cpp
+index af4d3efa52f..b089d91480d 100644
+--- a/tools/llvm-ar/llvm-ar.cpp
++++ b/tools/llvm-ar/llvm-ar.cpp
+@@ -167,9 +167,7 @@ static std::vector<StringRef> Members;
+ // Show the error message, the help message and exit.
+ LLVM_ATTRIBUTE_NORETURN static void
+ show_help(const std::string &msg) {
+-  errs() << ToolName << ": " << msg << "\n\n";
+-  cl::PrintHelpMessage();
+-  exit(1);
++  report_fatal_error(msg);
+ }
+ 
+ // Extract the member filename from the command line for the [relpos] argument
+@@ -275,7 +273,7 @@ static ArchiveOperation parseCommandLine() {
+       Thin = true;
+       break;
+     default:
+-      cl::PrintHelpMessage();
++      show_help("Invalid option");
+     }
+   }
+ 

--- a/llvm-head/llvm.nix
+++ b/llvm-head/llvm.nix
@@ -36,6 +36,8 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ncurses zlib ];
 
+  patches = [./llvm-ar.patch];
+
   postPatch = stdenv.lib.optionalString (enableSharedLibraries) ''
     substitute '${./llvm-outputs.patch}' ./llvm-outputs.patch --subst-var lib
     patch -p1 < ./llvm-outputs.patch

--- a/llvm-head/sources.nix
+++ b/llvm-head/sources.nix
@@ -2,8 +2,8 @@
   clang = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "clang";
-    rev = "7db24143e836a8d389bffec055f32df55a6c081c";
-    sha256 = "1z1jzk2kbiy5s7flkihpsx6jrfaq0hq2r9m53x1r072yfz5w7v4l";
+    rev = "3084e0523123d62965567245dbbde3527a307a66";
+    sha256 = "01f87dzg6d9ky8calj886k2xzijafkqsz9lq63mpb4lw5cj0m704";
   };
   libcxxabi = fetchFromGitHub {
     owner = "llvm-mirror";
@@ -14,43 +14,43 @@
   llvm = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "llvm";
-    rev = "cb8d6dea184609512650a6c599ef851518027954";
-    sha256 = "1qkqyqh7gprb54phav9ap46aw78qjqxjb1j4vlmi2san5mw9gqgv";
+    rev = "2368d9f73de09cd5ff2ac44b70cbd9128893c036";
+    sha256 = "0j2058i39arz788zmnzjv5hc220dr72scjpgb0zz009m64y0clzw";
   };
   libcxx = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "libcxx";
-    rev = "b859a78a6f02bc29e9ccb749adc79f842a18e2e8";
-    sha256 = "1nabj6qd95iyxszrxql1g4j8f5qyy1hrv8lawz5m1wcqpc7v8ziz";
+    rev = "e8c8bc94334771877d0ec962da5fb9d5b35cd85b";
+    sha256 = "1qkmjmggqlw58kr8h72rc9bhw3fmxa51sfrikdjzkp0xszmr1bkg";
   };
   lldb = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "lldb";
-    rev = "ec3c23cb370a881bf2074d4eee85e03f88f2d149";
-    sha256 = "1jrjz2y1zikqrs8gx90bbcj2hml1rl8nw1qm16bsrxkqz69h9fp9";
+    rev = "91e77b77aa6f28ea8d66bf7ec0e36bf28125eeb2";
+    sha256 = "1v74vknf97gz6jx69nrx18ln44gcm2s270dwjmc67kb5p864pnz2";
   };
   clang-tools-extra = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "clang-tools-extra";
-    rev = "2f301f50187ede4b9b8c7456ac4a67b9f7418004";
-    sha256 = "03zad73mz13cv4c4iabax3p4bg7n5izm6zwwvmpw1rqjbd1ifr5w";
+    rev = "c543235c134fbb02fb630eaa53661b188068b267";
+    sha256 = "1pcgaxvirrrlin6h10xplpmnbi6jq0gzkbhxgz2wijw1y67f0n93";
   };
   libunwind = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "libunwind";
-    rev = "4f4c5d0784c1c23c85baa3ffe301f7256a5217bc";
-    sha256 = "16k842nrin0187bpkmwl2ma01c2qz8zs1rlyarirzbkly091bw6v";
+    rev = "863d60e293b57fc41089cf3ff63a8cf174c30c65";
+    sha256 = "0cav2zb1j56i3lvld1l9gv022djpirhj75hnx2cnai0bc2jscxqa";
   };
   compiler-rt = fetchFromGitHub {
     owner = "llvm-mirror";
     repo = "compiler-rt";
-    rev = "4a6d122a262547d4c6978bc6c87a9d417109fe61";
-    sha256 = "0qbwgi5mgbhcqzzwfarhhgfgdrhk7hsk0n9izin697r295fhsk4a";
+    rev = "422f200cdfd54bee317d925981b24b177bd46297";
+    sha256 = "0ixn73isd9q6y36lcb8drw8704jr5mvqvwlmd9njfp6yzrnnrr7l";
   };
   lld = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "lld";
-    rev = "196bcc693535ab48f9e0fd95bd10b712f3431b61";
-    sha256 = "02ipvmw5v51ggm0ypwq8zmd5xxw7z4s0dq25d5hjjph42rhgrwzp";
+    rev = "e60a10d19b1e351374bfe276e54e1c5ea35fae52";
+    sha256 = "13fi7dz7j8b6fxhz0x1m3wac49q42vq63i18zxdbb1qxpfm2qv0j";
   };
 }

--- a/musl-cross.nix
+++ b/musl-cross.nix
@@ -1,5 +1,5 @@
 { stdenv, hostPlatform, callPackage, enableSharedLibraries }:
 
-if hostPlatform.arch == "wasm32"
+if hostPlatform.arch or null == "wasm32"
 then callPackage ./musl-wasm32.nix { inherit stdenv; }
 else callPackage ./musl-generic.nix { inherit stdenv enableSharedLibraries; }

--- a/musl-cross.nix
+++ b/musl-cross.nix
@@ -1,5 +1,5 @@
-{ stdenv, hostPlatform, callPackage, enableSharedLibraries }:
+{ stdenv, hostPlatform, callPackage }:
 
 if hostPlatform.arch or null == "wasm32"
 then callPackage ./musl-wasm32.nix { inherit stdenv; }
-else callPackage ./musl-generic.nix { inherit stdenv enableSharedLibraries; }
+else callPackage ./musl-generic.nix { inherit stdenv; }

--- a/musl-generic.nix
+++ b/musl-generic.nix
@@ -1,15 +1,21 @@
-{ stdenv, lib, enableSharedLibraries ? true, buildPlatform, hostPlatform, fetchgit }:
+{ stdenv, lib, buildPlatform, hostPlatform, fetchgit }:
 
 stdenv.mkDerivation ({
   name = "musl";
   src = fetchgit {
     url = "git://git.musl-libc.org/musl";
-    rev = "a08910fc2cc739f631b75b2d09b8d72a0d64d285";
-    sha256 = "1dz743sq9qb7y27xab2s81xla95w9whvahg22m152phjbkwcg9n1";
+    rev = "8fe1f2d79b275b7f7fb0d41c99e379357df63cd9";
+    sha256 = "1675ach4xpylhahrhxcjcsrr49y0ypck2a6k6q7fr5cysyxi1d9g";
   };
-} // lib.optionalAttrs (!enableSharedLibraries) {
-  configureFlags = "--disable-shared --enable-static";
-  makeFlags = ["lib/libc.a"];
+
+  installPhase = ''
+    mkdir $out
+    make install
+    for f in crtbegin crtend crtbeginS crtendS; do
+      touch $f.c
+      $CC -c -o $out/lib/$f.o $f.c
+    done
+  '';
 } // lib.optionalAttrs (hostPlatform != buildPlatform) {
   CROSS_COMPILE = "${hostPlatform.config}-";
 })

--- a/musl-generic.nix
+++ b/musl-generic.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation ({
       touch $f.c
       $CC -c -o $out/lib/$f.o $f.c
     done
+    for f in libgcc libgcc_s; do
+      touch $f.c
+      $CC -c -o $f.o $f.c
+      ''${AR-ar} rc $out/lib/$f.a $f.o
+    done
   '';
 } // lib.optionalAttrs (hostPlatform != buildPlatform) {
   CROSS_COMPILE = "${hostPlatform.config}-";

--- a/musl-wasm32.nix
+++ b/musl-wasm32.nix
@@ -7,4 +7,10 @@ stdenv.mkDerivation {
     rev = "ae1446d70619e6b5f99fa49fe34cc23264d46d7e";
     sha256 = "1zp43pf5yg2vrc1c3w29vfv2xrjk788h58lfqxf0ww78ifpr6kal";
   };
+
+  installPhase = ''
+    mkdir -p $out
+    make install
+    touch $out/lib/wasm.syms
+  '';
 }

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -1,1 +1,0 @@
-import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,6 +1,0 @@
-{
-  "owner": "WebGHC",
-  "repo": "nixpkgs",
-  "rev": "381eee210fe260175fec2f03db455c44456cb7d8",
-  "sha256": "1d7lrz9n4fbzz4vdjmwc4whglr2k8kfys7mlcbqs2zkqif6vmr4i"
-}

--- a/nixpkgs/github.json
+++ b/nixpkgs/github.json
@@ -1,6 +1,6 @@
 {
   "owner": "WebGHC",
   "repo": "nixpkgs",
-  "rev": "fda791ef2145506799ad02737e7211cc5f19b0d7",
-  "sha256": "03xbsijghx482ahz5znx6lpn2lzgafgydr1p27rk480dpnrr9b3m"
+  "rev": "381eee210fe260175fec2f03db455c44456cb7d8",
+  "sha256": "1d7lrz9n4fbzz4vdjmwc4whglr2k8kfys7mlcbqs2zkqif6vmr4i"
 }


### PR DESCRIPTION
This PR creates the `nativeNixpkgs` package set, which allows one to build native packages using the same custom toolchain as the wasm and aarch64 package sets.

However, the bulk of this PR is for getting GHC to build packages for aarch64, which sort of changed what I was using the word "native" for =P