### PR TITLE
Remove the rtlib arg on wasm

### DIFF
--- a/cross.nix
+++ b/cross.nix
@@ -100,7 +100,7 @@ in bootStages ++ [
       inherit ldFlags;
     };
     clangCross = mkClang {
-      ccFlags = "-rtlib=compiler-rt -resource-dir ${compiler-rt}";
+      ccFlags = toolPackages.lib.optionalString (!crossSystem.isWasm) "-rtlib=compiler-rt " + "-resource-dir ${compiler-rt}";
       inherit ldFlags;
       libc = musl-cross;
     };


### PR DESCRIPTION
Putting this in a PR partly to see what's up with Hydra dealing with PRs... Anyway, this change is harmless on wasm and should reduce the warning noise. IIRC, `-nostdlib++` is the only other excessive warning we generate, but we can't get past CMake's C++ compiler test without that (despite that we don't yet support C++).